### PR TITLE
feat: conditional dd logging setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
       TF_VAR_log_level: "debug"
       TF_VAR_private_key: ${{ secrets.PRIVATE_KEY }}
       TF_VAR_server_admin_token: ${{ secrets.SERVER_ADMIN_TOKEN }}
+      TF_VAR_dd_api_key: ${{ secrets.DD_API_KEY }}
     name: Deploy Infra to AWS
     steps:
       - name: Checkout code

--- a/config/modules/service/datadog.tf
+++ b/config/modules/service/datadog.tf
@@ -1,0 +1,95 @@
+locals {
+  DEFAULT_LOG_CONFIG = {
+    logDriver = "awslogs",
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.container.name,
+      awslogs-region        = var.region,
+      awslogs-stream-prefix = "logs"
+    }
+  }
+  DD_LOG_CONFIG = {
+    logDriver = "awsfirelens",
+    options = {
+      Name       = "datadog",
+      apiKey     = var.dd_api_key,
+      dd_service = var.container_family,
+      dd_source  = "fargate-app",
+      dd_tags    = "environment:${var.environment},service:${var.container_family}",
+      TLS        = "on",
+      provider   = "ecs"
+    }
+  }
+  DD_CONTAINER_DEF = {
+    name  = "datadog-agent-${var.environment}-${var.container_family}",
+    image = "public.ecr.aws/datadog/agent:7.40.1",
+    environment = [
+      {
+        name  = "DD_API_KEY",
+        value = var.dd_api_key
+      },
+      {
+        name  = "ECS_FARGATE",
+        value = "true"
+      },
+      {
+        name  = "DD_APM_ENABLED",
+        value = "true"
+      },
+      {
+        name  = "DD_DOGSTATSD_NON_LOCAL_TRAFFIC",
+        value = "true"
+      },
+
+      {
+        name  = "DD_APM_NON_LOCAL_TRAFFIC",
+        value = "true"
+      },
+
+      {
+        name  = "DD_PROCESS_AGENT_ENABLED",
+        value = "true"
+      },
+
+      {
+        name  = "DD_TRACE_ANALYTICS_ENABLED",
+        value = "true"
+      },
+
+      {
+        name  = "DD_RUNTIME_METRICS_ENABLED",
+        value = "true"
+      },
+
+      {
+        name  = "DD_LOGS_INJECTION",
+        value = "true"
+      }
+    ]
+
+    port_mappings = [
+      {
+        containerPort = 8126
+        hostPort      = 8126
+        protocol      = "tcp"
+      },
+      {
+        containerPort = 8125
+        hostPort      = 8125
+        protocol      = "udp"
+      },
+    ]
+  }
+
+  FLUENT_BIT_CONTAINER_DEF = {
+    name  = "fluent-bit-agent-${var.environment}-${var.container_family}",
+    image = "public.ecr.aws/aws-observability/aws-for-fluent-bit:2.28.4",
+    firelensConfiguration = {
+      type = "fluentbit",
+      options = {
+        enable-ecs-log-metadata = "true"
+        config-file-type        = "file"
+        config-file-value       = "/fluent-bit/configs/parse-json.conf"
+      }
+    }
+  }
+}

--- a/config/modules/service/main.tf
+++ b/config/modules/service/main.tf
@@ -41,30 +41,7 @@ resource "aws_ecs_task_definition" "service" {
     Project     = var.project_tag
     Environment = var.environment
   }
-  container_definitions = jsonencode([
-    {
-      name   = "${var.environment}-${var.container_family}"
-      image  = var.docker_image
-      cpu    = var.cpu
-      memory = var.memory
-      environment = concat(var.container_env_vars, [
-        { name = "REDIS_URL", value = "redis://${var.redis_url}:${var.redis_port}" },
-        var.enable_dd_logging ? { name = "DD_SERVICE", value = var.container_family } : {},
-      ])
-      networkMode      = "awsvpc"
-      logConfiguration = var.enable_dd_logging ? local.DD_LOG_CONFIG : local.DEFAULT_LOG_CONFIG
-      portMappings = [
-        {
-          containerPort = var.container_port
-          hostPort      = var.container_port
-        }
-      ]
-      repositoryCredentials = {
-        credentialsParameter = aws_secretsmanager_secret.github_creds.arn
-      }
-    },
-    var.enable_dd_logging ? [local.DD_CONTAINER_DEF, local.FLUENT_BIT_CONTAINER_DEF] : []
-  ])
+  container_definitions = var.enable_dd_logging ? local.DD_ENABLED_CONTAINER_DEF : local.DD_DISABLED_CONTAINER_DEF
 }
 
 

--- a/config/modules/service/variables.tf
+++ b/config/modules/service/variables.tf
@@ -89,6 +89,7 @@ variable "redis_port" {
 
 variable "dd_api_key" {
   type        = string
+  default     = null
   description = "Datadog API key."
 }
 

--- a/config/modules/service/variables.tf
+++ b/config/modules/service/variables.tf
@@ -86,3 +86,14 @@ variable "redis_port" {
   type        = string
   description = "Redis port."
 }
+
+variable "dd_api_key" {
+  type        = string
+  description = "Datadog API key."
+}
+
+variable "enable_dd_logging" {
+  type        = bool
+  default     = false
+  description = "Enable datadog logging. Otherwise, default to CW."
+}

--- a/config/testnet-staging/main.tf
+++ b/config/testnet-staging/main.tf
@@ -44,6 +44,8 @@ module "watcher" {
   github_token             = var.github_token
   redis_url                = module.redis_cache.redis_instance_address
   redis_port               = module.redis_cache.redis_instance_port
+  enable_dd_logging        = true
+  dd_api_key               = var.dd_api_key
 }
 
 module "redis_cache" {

--- a/config/testnet-staging/variables.tf
+++ b/config/testnet-staging/variables.tf
@@ -165,3 +165,9 @@ variable "tenderly_project_slug" {
   type    = string
   default = null
 }
+
+variable "dd_api_key" {
+  type        = string
+  default     = null
+  description = "Datadog API key."
+}


### PR DESCRIPTION
Implements conditional set up of DD logging. Currently set up only on `testnet-staging`

This adds 2 variables to the `service` module:
- `enable_dd_logging` as a boolean flag
- `dd_api_key` as a string

If `enable_dd_logging` is set to true, the service will run 2 more containers: the DD agent, and the fluent-bit container for log parsing. 

